### PR TITLE
Also check for non-fully-qualified constant usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fqn-check
 
-Checks source trees for fully qualified function calls.
+Checks source trees for fully qualified function calls and constants.
 
 ## Installation
 
@@ -14,7 +14,7 @@ composer require --dev kelunik/fqn-check
 vendor/bin/fqn-check /path/to/source
 ```
 
-All not fully qualified function calls will be listed and the exit code will be `1` if any such function call is found, `0` otherwise.
+All not fully qualified function calls and constants will be listed and the exit code will be `1` if any such function call is found, `0` otherwise.
 
 ## Alternatives
 

--- a/bin/fqn-check
+++ b/bin/fqn-check
@@ -49,7 +49,7 @@ foreach ($files as $file) {
 
     foreach ($findings as $finding) {
         if ($errors === 0) {
-            print "Found not fully qualified function calls in the following files:" . PHP_EOL;
+            print "Found not fully qualified function calls and/or constants in the following files:" . PHP_EOL;
         }
 
         $errors++;
@@ -63,6 +63,6 @@ if ($errors === 0) {
     exit(0);
 } else {
     print PHP_EOL;
-    print "Found {$errors} not fully qualified function calls.";
+    print "Found {$errors} not fully qualified function calls and/or constants.";
     exit(1);
 }

--- a/src/FqnChecker.php
+++ b/src/FqnChecker.php
@@ -21,7 +21,7 @@ class FqnChecker implements NodeVisitor {
     }
 
     public function enterNode(Node $node) {
-        if (!$node instanceof Node\Expr\FuncCall) {
+        if (!($node instanceof Node\Expr\FuncCall || $node instanceof Node\Expr\ConstFetch)) {
             return;
         }
 
@@ -30,6 +30,10 @@ class FqnChecker implements NodeVisitor {
         }
 
         if ($node->name->isFullyQualified()) {
+            return;
+        }
+
+        if (in_array(\strtolower($node->name->toString()), ['true', 'false', 'null'], true)) {
             return;
         }
 


### PR DESCRIPTION
This PR adds the ability to locate constants which are not fully-qualified.

-----

Code like this:

```
<?php

namespace foo;

echo PHP_VERSION;
```

Will produce opcodes like this:

```
number of ops:  5
compiled vars:  none
line     #* E I O op                           fetch          ext  return  operands
-------------------------------------------------------------------------------------
   3     0  E >   NOP                                                      
   7     1        EXT_STMT                                                 
         2        FETCH_CONSTANT                                   ~0      'foo%5CPHP_VERSION'
         3        ECHO                                                     ~0
   8     4      > RETURN                                                   1
```

However, if we were to fully-qualify that constant as `\PHP_VERSION` or a `use const \PHP_VERSION` we'd get the following optimized opcodes instead:

```
number of ops:  4
compiled vars:  none
line     #* E I O op                           fetch          ext  return  operands
-------------------------------------------------------------------------------------
   3     0  E >   NOP                                                      
   7     1        EXT_STMT                                                 
         2        ECHO                                                     '7.1.32-1%2Bubuntu18.04.1%2Bdeb.sury.org%2B1'
   8     3      > RETURN                                                   1
```