### PR TITLE
Fix PhpParser error (use current PHP version, not always PHP 8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
-/vendor/
+# Project
+.idea
+*.iml
+
+# Composer
+composer.phar
+vendor/

--- a/bin/fqn-check
+++ b/bin/fqn-check
@@ -2,6 +2,7 @@
 <?php
 
 use Kelunik\FqnCheck\FqnChecker;
+use PhpParser\Lexer;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\ParserFactory;
@@ -28,7 +29,7 @@ $files = (new Finder)->files()
     ->in($srcDir)
     ->name("*.php");
 
-$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
+$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7, new Lexer());
 $nodeTraverser = new NodeTraverser;
 
 $fqnChecker = new FqnChecker;


### PR DESCRIPTION
As described by the PhpParser devs, your library treats code as PHP8 where possible. They suggested to add `new Lexer()` to the parser: https://github.com/nikic/PHP-Parser/issues/715#issuecomment-697195312